### PR TITLE
issue running hydra with cucumber

### DIFF
--- a/lib/hydra/tasks.rb
+++ b/lib/hydra/tasks.rb
@@ -36,6 +36,8 @@ module Hydra #:nodoc:
     # files that may not play nice with others.
     attr_accessor :serial
 
+    attr_accessor :environment
+
     #
     # Search for the hydra config file
     def find_config_file
@@ -91,7 +93,8 @@ module Hydra #:nodoc:
         :verbose => @verbose,
         :autosort => @autosort,
         :files => @files,
-        :listeners => @listeners
+        :listeners => @listeners,
+        :environment => @environment
       }
       if @config
         @opts.merge!(:config => @config)


### PR DESCRIPTION
It looks like hydra doesn't pass the environment down to SSH workers correctly so the tests were running under a RAILS environment of test rather than cucumber.  This may not be the most appropriate way to set the environment, but hopefully can spur a fix.

I had to customize testjour a little bit a while ago for our test farm back before there wasn't anything on Google about it, but it's not nearly as current as hydra is with cucumber.  Thanks a lot for this great piece of software.

Feel free to check out the post I made a while back, you might be interested in my capistrano script on the third page.  I used git to sync up everything to a master server which then used the regular testjour rsync process.  We were eventually going to make it sync with git, git diff, rsync the diff, and patch but never got around to doing that, so it was bound to the last local commit.
http://openphin.blogspot.com/2009/11/getting-testjour-up-and-running.html
