### PR TITLE
Remote command

### DIFF
--- a/test/fixtures/task_test_config.yml
+++ b/test/fixtures/task_test_config.yml
@@ -1,0 +1,6 @@
+---
+  workers:
+    - type: ssh
+      connect: localhost
+      directory: /tmp
+      runners: 1

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -1,0 +1,21 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+require 'hydra/tasks'
+require 'rake'
+
+class TaskTest < Test::Unit::TestCase
+  context "a task" do
+    should "execute the command in a remote machine" do
+      
+      File.delete( "/tmp/new_file" ) if File.exists? "/tmp/new_file"
+
+      Hydra::RemoteTask.new('cat:text_file', 'touch new_file') do |t|
+        t.config = "test/fixtures/task_test_config.yml"
+      end
+
+      Rake.application['hydra:remote:cat:text_file'].invoke
+
+      assert( File.exists? "/tmp/new_file" )
+      
+    end
+  end
+end


### PR DESCRIPTION
Hi Nick,
Made a modification to the RemoteTask that allows you to run arbitrary commands.  This is super helpful when you are using Bundler and have a bunch of remote machines that need to have a 'bundle install' run on them.

task 'hydra:remote:bundle:install' => 'hydra:sync'
Hydra::RemoteTask.new('bundle:install', 'bundle install')

Let me know what you think.

Cheers,
Sean
