### PR TITLE
Runners event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ coverage
 rdoc
 pkg
 tags
+.rvmrc
 
 ## PROJECT::SPECIFIC

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ rdoc
 pkg
 tags
 .rvmrc
+hydra-runner.log
 
 ## PROJECT::SPECIFIC

--- a/lib/hydra.rb
+++ b/lib/hydra.rb
@@ -13,4 +13,4 @@ require 'hydra/listener/minimal_output'
 require 'hydra/listener/report_generator'
 require 'hydra/listener/notifier'
 require 'hydra/listener/progress_bar'
-
+require 'hydra/runner_listener/abstract'

--- a/lib/hydra/master.rb
+++ b/lib/hydra/master.rb
@@ -173,8 +173,6 @@ module Hydra #:nodoc:
     def boot_ssh_worker(worker)
       sync = Sync.new(worker, @sync, @verbose)
 
-#      @environment+=" bundle exec" #used for manually testing
-
       runners = worker.fetch('runners') { raise "You must specify the number of runners"  }
       command = worker.fetch('command') {
         "RAILS_ENV=#{@environment} ruby -e \"require 'rubygems'; require 'hydra'; Hydra::Worker.new(:io => Hydra::Stdio.new, :runners => #{runners}, :verbose => #{@verbose}, :runner_listeners => \'#{@string_runner_event_listeners}\' );\""

--- a/lib/hydra/master.rb
+++ b/lib/hydra/master.rb
@@ -67,6 +67,7 @@ module Hydra #:nodoc:
 
       @string_runner_event_listeners = Array( opts.fetch( 'runner_listeners' ) { nil } )
 
+      @runner_log_file = opts.fetch('runner_log_file') { nil }
       @verbose = opts.fetch('verbose') { false }
       @autosort = opts.fetch('autosort') { true }
       @sync = opts.fetch('sync') { nil }
@@ -163,7 +164,7 @@ module Hydra #:nodoc:
       pipe = Hydra::Pipe.new
       child = SafeFork.fork do
         pipe.identify_as_child
-        Hydra::Worker.new(:io => pipe, :runners => runners, :verbose => @verbose, :runner_listeners => @string_runner_event_listeners )
+        Hydra::Worker.new(:io => pipe, :runners => runners, :verbose => @verbose, :runner_listeners => @string_runner_event_listeners, :runner_log_file => @runner_log_file )
       end
 
       pipe.identify_as_parent
@@ -175,7 +176,7 @@ module Hydra #:nodoc:
 
       runners = worker.fetch('runners') { raise "You must specify the number of runners"  }
       command = worker.fetch('command') {
-        "RAILS_ENV=#{@environment} ruby -e \"require 'rubygems'; require 'hydra'; Hydra::Worker.new(:io => Hydra::Stdio.new, :runners => #{runners}, :verbose => #{@verbose}, :runner_listeners => \'#{@string_runner_event_listeners}\' );\""
+        "RAILS_ENV=#{@environment} ruby -e \"require 'rubygems'; require 'hydra'; Hydra::Worker.new(:io => Hydra::Stdio.new, :runners => #{runners}, :verbose => #{@verbose}, :runner_listeners => \'#{@string_runner_event_listeners}\', :runner_log_file => \'#{@runner_log_file}\' );\""
       }
 
       trace "Booting SSH worker"

--- a/lib/hydra/master.rb
+++ b/lib/hydra/master.rb
@@ -64,6 +64,9 @@ module Hydra #:nodoc:
         listener = eval(l)
         @event_listeners << listener if listener.is_a?(Hydra::Listener::Abstract)
       end
+
+      @string_runner_event_listeners = Array( opts.fetch( 'runner_listeners' ) { nil } )
+
       @verbose = opts.fetch('verbose') { false }
       @autosort = opts.fetch('autosort') { true }
       @sync = opts.fetch('sync') { nil }
@@ -160,7 +163,7 @@ module Hydra #:nodoc:
       pipe = Hydra::Pipe.new
       child = SafeFork.fork do
         pipe.identify_as_child
-        Hydra::Worker.new(:io => pipe, :runners => runners, :verbose => @verbose)
+        Hydra::Worker.new(:io => pipe, :runners => runners, :verbose => @verbose, :runner_listeners => @string_runner_event_listeners )
       end
 
       pipe.identify_as_parent
@@ -170,9 +173,11 @@ module Hydra #:nodoc:
     def boot_ssh_worker(worker)
       sync = Sync.new(worker, @sync, @verbose)
 
+#      @environment+=" bundle exec" #used for manually testing
+
       runners = worker.fetch('runners') { raise "You must specify the number of runners"  }
       command = worker.fetch('command') {
-        "RAILS_ENV=#{@environment} ruby -e \"require 'rubygems'; require 'hydra'; Hydra::Worker.new(:io => Hydra::Stdio.new, :runners => #{runners}, :verbose => #{@verbose});\""
+        "RAILS_ENV=#{@environment} ruby -e \"require 'rubygems'; require 'hydra'; Hydra::Worker.new(:io => Hydra::Stdio.new, :runners => #{runners}, :verbose => #{@verbose}, :runner_listeners => \'#{@string_runner_event_listeners}\' );\""
       }
 
       trace "Booting SSH worker"

--- a/lib/hydra/runner.rb
+++ b/lib/hydra/runner.rb
@@ -40,8 +40,10 @@ module Hydra #:nodoc:
     end
 
     def reg_trap_sighup
-      trap :SIGHUP do
-        stop
+      for sign in [:SIGHUP, :INT]
+        trap sign do
+          stop
+        end
       end
       @runner_began = true
     end
@@ -295,6 +297,8 @@ module Hydra #:nodoc:
       begin
         $stderr = $stdout =  File.open(file_name, 'a')
       rescue
+        # it should always redirect output in order to handle unexpected interruption
+        # successfully
         $stderr = $stdout =  File.open(DEFAULT_LOG_FILE, 'a')
       end
     end

--- a/lib/hydra/runner.rb
+++ b/lib/hydra/runner.rb
@@ -16,7 +16,7 @@ module Hydra #:nodoc:
     # Boot up a runner. It takes an IO object (generally a pipe from its
     # parent) to send it messages on which files to execute.
     def initialize(opts = {})
-      redirect_output
+      redirect_output( opts.fetch( :runner_log_file ) { nil } )
       reg_trap_sighup
 
       @io = opts.fetch(:io) { raise "No IO Object" }
@@ -289,9 +289,8 @@ module Hydra #:nodoc:
       end.compact
     end
 
-    def redirect_output file_name = nil
-      file_name = 'log/hydra.log' if !file_name and File.exists? 'log/'
-      file_name = 'hydra.log' unless file_name
+    def redirect_output file_name
+      file_name = '/dev/null' unless file_name and !file_name.empty?
       $stderr = $stdout =  File.open(file_name, 'a')
     end
   end

--- a/lib/hydra/runner_listener/abstract.rb
+++ b/lib/hydra/runner_listener/abstract.rb
@@ -1,0 +1,23 @@
+module Hydra #:nodoc:
+  module RunnerListener #:nodoc:
+    # Abstract listener that implements all the events
+    # but does nothing.
+    class Abstract
+      # Create a new listener.
+      #
+      # Output: The IO object for outputting any information.
+      # Defaults to STDOUT, but you could pass a file in, or STDERR
+      def initialize(output = $stdout)
+        @output = output
+      end
+
+      # Fired by the runner just before requesting the first file
+      def runner_begin
+      end
+
+      # Fired by the runner just after stoping
+      def runner_end
+      end
+    end
+  end
+end

--- a/lib/hydra/runner_listener/abstract.rb
+++ b/lib/hydra/runner_listener/abstract.rb
@@ -12,11 +12,11 @@ module Hydra #:nodoc:
       end
 
       # Fired by the runner just before requesting the first file
-      def runner_begin
+      def runner_begin( runner )
       end
 
       # Fired by the runner just after stoping
-      def runner_end
+      def runner_end( runner )
       end
     end
   end

--- a/lib/hydra/tasks.rb
+++ b/lib/hydra/tasks.rb
@@ -41,6 +41,10 @@ module Hydra #:nodoc:
     # Set to false if you don't want to show the total running time
     attr_accessor :show_time
 
+    # Set to a valid file path if you want to save the output of the runners
+    # in a log file
+    attr_accessor :runner_log_file
+
     #
     # Search for the hydra config file
     def find_config_file
@@ -98,7 +102,8 @@ module Hydra #:nodoc:
         :autosort => @autosort,
         :files => @files,
         :listeners => @listeners,
-        :environment => @environment
+        :environment => @environment,
+        :runner_log_file => @runner_log_file
       }
       if @config
         @opts.merge!(:config => @config)

--- a/lib/hydra/worker.rb
+++ b/lib/hydra/worker.rb
@@ -28,6 +28,7 @@ module Hydra #:nodoc:
         listener = eval(l)
         @runner_event_listeners << listener if listener.is_a?(Hydra::RunnerListener::Abstract)
       end
+      @runner_log_file = opts.fetch(:runner_log_file) { nil }
 
       boot_runners(opts.fetch(:runners) { 1 })
       @io.write(Hydra::Messages::Worker::WorkerBegin.new)
@@ -91,7 +92,7 @@ module Hydra #:nodoc:
         pipe = Hydra::Pipe.new
         child = SafeFork.fork do
           pipe.identify_as_child
-          Hydra::Runner.new(:io => pipe, :verbose => @verbose, :runner_listeners => @runner_event_listeners )
+          Hydra::Runner.new(:io => pipe, :verbose => @verbose, :runner_listeners => @runner_event_listeners, :runner_log_file => @runner_log_file )
         end
         pipe.identify_as_parent
         @runners << { :pid => child, :io => pipe, :idle => false }

--- a/lib/hydra/worker.rb
+++ b/lib/hydra/worker.rb
@@ -130,7 +130,6 @@ module Hydra #:nodoc:
           rescue IOError => ex
             trace "Worker lost Master"
             shutdown
-            #Thread.exit
           end
         end
       end

--- a/test/fixtures/hydra_worker_init.rb
+++ b/test/fixtures/hydra_worker_init.rb
@@ -1,0 +1,2 @@
+require '../test/fixtures/runner_listeners.rb'
+require '../test/fixtures/master_listeners.rb'

--- a/test/fixtures/master_listeners.rb
+++ b/test/fixtures/master_listeners.rb
@@ -1,0 +1,10 @@
+module HydraExtension
+  module Listener
+    class WorkerBeganFlag < Hydra::Listener::Abstract
+      # Fired after runner processes have been started
+      def worker_begin(worker)
+        FileUtils.touch File.expand_path(File.join(Dir.consistent_tmpdir, 'worker_began_flag'))
+      end
+    end
+  end
+end

--- a/test/fixtures/runner_listeners.rb
+++ b/test/fixtures/runner_listeners.rb
@@ -8,9 +8,14 @@ module HydraExtension
     end
 
     class RunnerEndTest < Hydra::RunnerListener::Abstract
+      # Fired by the runner just before requesting the first file
+      def runner_begin( runner )
+        FileUtils.touch File.expand_path(File.join(Dir.consistent_tmpdir, 'runner_began_flag')) #used to know when the runner is ready
+      end
       # Fired by the runner just after stoping
       def runner_end( runner )
         # NOTE: do not use trace here
+        #runner.trace "Ending runner"
         FileUtils.touch File.expand_path(File.join(Dir.consistent_tmpdir, 'alternate_hydra_test.txt'))
       end
     end

--- a/test/fixtures/runner_listeners.rb
+++ b/test/fixtures/runner_listeners.rb
@@ -1,17 +1,17 @@
-require File.join(File.dirname(__FILE__), '..', 'test_helper')
-
-module RunnerListener
-  class RunnerBeginTest < Hydra::RunnerListener::Abstract
-    # Fired by the runner just before requesting the first file
-    def runner_begin
-      FileUtils.touch File.expand_path(File.join(Dir.consistent_tmpdir, 'alternate_hydra_test.txt'))
+module HydraExtension
+  module RunnerListener
+    class RunnerBeginTest < Hydra::RunnerListener::Abstract
+      # Fired by the runner just before requesting the first file
+      def runner_begin( runner )
+        FileUtils.touch File.expand_path(File.join(Dir.consistent_tmpdir, 'alternate_hydra_test.txt'))
+      end
     end
-  end
 
-  class RunnerEndTest < Hydra::RunnerListener::Abstract
-    # Fired by the runner just after stoping
-    def runner_end
-      FileUtils.touch File.expand_path(File.join(Dir.consistent_tmpdir, 'alternate_hydra_test.txt'))
+    class RunnerEndTest < Hydra::RunnerListener::Abstract
+      # Fired by the runner just after stoping
+      def runner_end( runner )
+        FileUtils.touch File.expand_path(File.join(Dir.consistent_tmpdir, 'alternate_hydra_test.txt'))
+      end
     end
   end
 end

--- a/test/fixtures/runner_listeners.rb
+++ b/test/fixtures/runner_listeners.rb
@@ -1,0 +1,17 @@
+require File.join(File.dirname(__FILE__), '..', 'test_helper')
+
+module RunnerListener
+  class RunnerBeginTest < Hydra::RunnerListener::Abstract
+    # Fired by the runner just before requesting the first file
+    def runner_begin
+      FileUtils.touch File.expand_path(File.join(Dir.consistent_tmpdir, 'alternate_hydra_test.txt'))
+    end
+  end
+
+  class RunnerEndTest < Hydra::RunnerListener::Abstract
+    # Fired by the runner just after stoping
+    def runner_end
+      FileUtils.touch File.expand_path(File.join(Dir.consistent_tmpdir, 'alternate_hydra_test.txt'))
+    end
+  end
+end

--- a/test/fixtures/runner_listeners.rb
+++ b/test/fixtures/runner_listeners.rb
@@ -10,6 +10,7 @@ module HydraExtension
     class RunnerEndTest < Hydra::RunnerListener::Abstract
       # Fired by the runner just after stoping
       def runner_end( runner )
+        # NOTE: do not use trace here
         FileUtils.touch File.expand_path(File.join(Dir.consistent_tmpdir, 'alternate_hydra_test.txt'))
       end
     end

--- a/test/master_test.rb
+++ b/test/master_test.rb
@@ -1,4 +1,6 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
+require File.join(File.dirname(__FILE__), 'fixtures', 'runner_listeners')
+require File.join(File.dirname(__FILE__), 'fixtures', 'master_listeners')
 
 class MasterTest < Test::Unit::TestCase
   context "with a file to test and a destination to verify" do
@@ -177,5 +179,111 @@ class MasterTest < Test::Unit::TestCase
       # ensure b is deleted
       assert !File.exists?(File.join(remote, 'test_b.rb')), "B was not deleted"
     end
+  end
+
+  context "with a runner_end event" do
+    setup do
+      # avoid having other tests interfering with us
+      sleep(0.2)
+      FileUtils.rm_f(target_file)
+      FileUtils.rm_f(alternate_target_file)
+
+      @worker_began_flag = File.expand_path(File.join(Dir.consistent_tmpdir, 'worker_began_flag')) #used to know when the worker is ready
+      FileUtils.rm_f(@worker_began_flag)
+
+      @runner_listener = 'HydraExtension::RunnerListener::RunnerEndTest.new' # runner_end method that creates alternate_target_file
+      @master_listener = HydraExtension::Listener::WorkerBeganFlag.new  #used to know when the runner is up
+    end
+
+    teardown do
+      FileUtils.rm_f(target_file)
+      FileUtils.rm_f(alternate_target_file)
+    end
+
+    context "running a local worker" do
+      setup do
+        @pid = Process.fork do
+          Hydra::Master.new(
+                            :files => [test_file] * 6,
+                            :autosort => false,
+                            :listeners => [@master_listener],
+                            :runner_listeners => [@runner_listener],
+                            :verbose => false
+                            )
+        end
+      end
+
+      should "run runner_end on successful termination" do
+        Process.waitpid @pid
+
+        assert File.exists?( target_file )
+
+        wait_for_file_for_a_while alternate_target_file, 2
+        assert File.exists? alternate_target_file
+      end
+
+      should "run runner_end after interruption signal" do
+        wait_for_runner_to_begin
+        Process.kill 'SIGINT', @pid
+        Process.waitpid @pid
+
+        wait_for_file_for_a_while alternate_target_file, 2
+        assert File.exists? alternate_target_file # runner_end should create this file
+      end
+    end
+
+    context "running a remote worker" do
+      setup do
+        copy_worker_init_file # this method has a protection to avoid erasing an existing worker_init_file
+        @pid = Process.fork do
+          Hydra::Master.new(
+                            :files => [test_file] * 6,
+                            :autosort => false,
+                            :listeners => [@master_listener],
+                            :runner_listeners => [@runner_listener],
+                            :workers => [{
+                                           :type => :ssh,
+                                           :connect => 'localhost',
+                                           :directory => remote_dir_path,
+                                           :runners => 1
+                                         }],
+                            :verbose => false
+                            )
+        end
+      end
+
+      teardown do
+        FileUtils.rm_f(@remote_init_file) unless @protect_init_file
+      end
+
+      should "run runner_end on successful termination" do
+        Process.waitpid @pid
+
+        wait_for_file_for_a_while alternate_target_file, 2
+        assert File.exists? target_file
+        assert File.exists? alternate_target_file
+      end
+    end
+  end
+
+  private
+  #  this requires that a worker_begin listener creates a file named worker_began_flag in tmp directory
+  def wait_for_runner_to_begin
+    FileUtils.rm_f(@worker_began_flag)
+
+    wait_for_file_for_a_while @worker_began_flag, 2
+    assert File.exists?( @worker_began_flag ), "The worker didn't begin!!"
+  end
+
+  # with a protection to avoid erasing something important in lib
+  def copy_worker_init_file
+    @remote_init_file = "#{remote_dir_path}/#{File.basename( hydra_worker_init_file )}"
+    if File.exists?( @remote_init_file )
+      $stderr.puts "\nWARNING!!!: #{@remote_init_file} exits and this test needs to create a new file here. Make sure there is nothing inportant in that file and remove it before running this test\n\n"
+      @protect_init_file = true
+      exit
+    end
+    # copy the hydra_worker_init to the correct location
+    FileUtils.cp(hydra_worker_init_file, remote_dir_path)
   end
 end

--- a/test/master_test.rb
+++ b/test/master_test.rb
@@ -205,12 +205,12 @@ class MasterTest < Test::Unit::TestCase
         capture_stderr do # redirect stderr
           @pid = Process.fork do
             Hydra::Master.new(
-                              :files => [test_file] * 6,
-                              :autosort => false,
-                              :listeners => [@master_listener],
-                              :runner_listeners => [@runner_listener],
-                              :verbose => false
-                              )
+              :files => [test_file] * 6,
+              :autosort => false,
+              :listeners => [@master_listener],
+              :runner_listeners => [@runner_listener],
+              :verbose => false
+            )
           end
         end
       end
@@ -242,18 +242,18 @@ class MasterTest < Test::Unit::TestCase
         capture_stderr do # redirect stderr
           @pid = Process.fork do
             Hydra::Master.new(
-                              :files => [test_file] * 6,
-                              :autosort => false,
-                              :listeners => [@master_listener],
-                              :runner_listeners => [@runner_listener],
-                              :workers => [{
-                                             :type => :ssh,
-                                             :connect => 'localhost',
-                                             :directory => remote_dir_path,
-                                             :runners => 1
-                                         }],
-                              :verbose => false
-                              )
+              :files => [test_file] * 6,
+              :autosort => false,
+              :listeners => [@master_listener],
+              :runner_listeners => [@runner_listener],
+              :workers => [{
+                :type => :ssh,
+                :connect => 'localhost',
+                :directory => remote_dir_path,
+                :runners => 1
+              }],
+              :verbose => false
+            )
           end
         end
       end

--- a/test/master_test.rb
+++ b/test/master_test.rb
@@ -115,8 +115,8 @@ class MasterTest < Test::Unit::TestCase
         :workers => [{
           :type => :ssh,
           :connect => 'localhost',
-          :directory => File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib')),
-          :runners => 1 
+          :directory => remote_dir_path,
+          :runners => 1
         }]
       )
       assert File.exists?(target_file)

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -137,17 +137,14 @@ class RunnerTest < Test::Unit::TestCase
           Process.wait(@parent)
 
           # ensure runner_begin was fired
-          assert File.exists?( alternate_target_file )
+          assert_file_exists alternate_target_file
         end
 
-        should "fire runner_end event after successful shutting down" do
+        should "fire runner_end event" do
           run_the_runner(@pipe,  [HydraExtension::RunnerListener::RunnerEndTest.new] )
           Process.wait(@parent)
 
-          wait_for_file_for_a_while alternate_target_file, 2
-
-          # ensure runner_end was fired
-          assert File.exists?( alternate_target_file )
+          assert_file_exists alternate_target_file
         end
       end
 
@@ -171,17 +168,6 @@ class RunnerTest < Test::Unit::TestCase
   end
 
   module RunnerTestHelper
-
-    #this method allow us to wait for a file for a maximum number of time, so the
-    #test can pass in slower machines. This helps to speed up the tests
-    def wait_for_file_for_a_while file, time_to_wait
-      time_begin = Time.now
-
-      until Time.now - time_begin >= time_to_wait or File.exists?( file ) do
-        sleep 0.01
-      end
-    end
-
     def request_a_file_and_verify_completion(pipe, file)
       pipe.identify_as_parent
 

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -98,7 +98,7 @@ class RunnerTest < Test::Unit::TestCase
     should "be able to run a runner over ssh" do
       ssh = Hydra::SSH.new(
         'localhost', 
-        File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib')),
+         remote_dir_path,
         "ruby -e \"require 'rubygems'; require 'hydra'; Hydra::Runner.new(:io => Hydra::Stdio.new, :verbose => true);\""
       )
       assert ssh.gets.is_a?(Hydra::Messages::Runner::RequestFile)

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -161,7 +161,7 @@ class RunnerTest < Test::Unit::TestCase
         run_the_runner(pipe,  [HydraExtension::RunnerListener::RunnerEndTest.new] )
         Process.wait(parent)
 
-        # ensure runner_begin was fired
+        # ensure runner_end was fired
         assert File.exists?( alternate_target_file )
       end
     end

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -107,7 +107,7 @@ class RunnerTest < Test::Unit::TestCase
           request_a_file_and_verify_completion(pipe, test_file)
         end
 
-        run_the_runner(pipe,  [RunnerListener::RunnerBeginTest.new] )
+        run_the_runner(pipe,  [HydraExtension::RunnerListener::RunnerBeginTest.new] )
         Process.wait(parent)
 
         # ensure runner_begin was fired
@@ -115,7 +115,7 @@ class RunnerTest < Test::Unit::TestCase
       end
 
       should "fire runner_end event after successful shutting down" do
-        send_file_to_ssh_runner_and_verify_completion ", :runner_listeners => [RunnerListener::RunnerEndTest.new]"
+        send_file_to_ssh_runner_and_verify_completion ", :runner_listeners => [HydraExtension::RunnerListener::RunnerEndTest.new]"
 
         wait_for_file_for_a_while alternate_target_file, 2
 
@@ -130,12 +130,10 @@ class RunnerTest < Test::Unit::TestCase
 
           # grab its response.
           response = pipe.gets
-
           pipe.close #this will be detected by the runner and it should call runner_end
-
         end
 
-        run_the_runner(pipe,  [RunnerListener::RunnerEndTest.new] )
+        run_the_runner(pipe,  [HydraExtension::RunnerListener::RunnerEndTest.new] )
         Process.wait(parent)
 
         # ensure runner_begin was fired

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,6 +56,10 @@ class Test::Unit::TestCase
   def conflicting_test_file
     File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', 'conflicting.rb'))
   end
+
+  def remote_dir_path
+    File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
+  end
 end
 
 module Hydra #:nodoc:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ gem 'shoulda', '2.10.3'
 gem 'rspec', '2.0.0.beta.19'
 require 'shoulda'
 require 'tmpdir'
+require "stringio"
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
@@ -63,6 +64,18 @@ class Test::Unit::TestCase
 
   def hydra_worker_init_file
     File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', 'hydra_worker_init.rb'))
+  end
+
+  def capture_stderr
+    # The output stream must be an IO-like object. In this case we capture it in
+    # an in-memory IO object so we can return the string value. You can assign any
+    # IO object here.
+    previous_stderr, $stderr = $stderr, StringIO.new
+    yield
+    $stderr.string
+  ensure
+    # Restore the previous value of stderr (typically equal to STDERR).
+    $stderr = previous_stderr
   end
 
   #this method allow us to wait for a file for a maximum number of time, so the

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,6 +60,20 @@ class Test::Unit::TestCase
   def remote_dir_path
     File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
   end
+
+  def hydra_worker_init_file
+    File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', 'hydra_worker_init.rb'))
+  end
+
+  #this method allow us to wait for a file for a maximum number of time, so the
+  #test can pass in slower machines. This helps to speed up the tests
+  def wait_for_file_for_a_while file, time_to_wait
+    time_begin = Time.now
+
+    until Time.now - time_begin >= time_to_wait or File.exists?( file ) do
+      sleep 0.01
+    end
+  end
 end
 
 module Hydra #:nodoc:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -80,12 +80,14 @@ class Test::Unit::TestCase
 
   #this method allow us to wait for a file for a maximum number of time, so the
   #test can pass in slower machines. This helps to speed up the tests
-  def wait_for_file_for_a_while file, time_to_wait
+  def assert_file_exists file, time_to_wait = 2
     time_begin = Time.now
 
     until Time.now - time_begin >= time_to_wait or File.exists?( file ) do
       sleep 0.01
     end
+
+    assert File.exists?( file )
   end
 end
 


### PR DESCRIPTION
Hi Nick,

I created runners event for hydra, and a way to handle unexpected termination. The runner_end event will be fired even in case of an interruption. I found this later case very hard to test.

I also wrote code to allow the runner to create log files. This will allow us to debug better when working in the runner level. I also found that in order to handle unexpected termination, we need to redirect the output of the runner because if the master dies, then the runner will raise an exception when writing to standard output, since this is no longer available. This redirection won't affect anything else since the communication between runner and worker is through the pipe.

Any question, just let me know,

Cheers,

Arturo
