### PR TITLE
add pass/fail info to hydra_heuristics.yml

### DIFF
--- a/lib/hydra/listener/report_generator.rb
+++ b/lib/hydra/listener/report_generator.rb
@@ -18,6 +18,7 @@ module Hydra #:nodoc:
       def file_end(file, output)
         @report[file]['end'] = Time.now.to_f
         @report[file]['duration'] = @report[file]['end'] - @report[file]['start']
+        @report[file]['all_tests_passed_last_run'] = (output == '.')
       end
 
       # output the report


### PR DESCRIPTION
Hi Nick,

This commit adds a "all_tests_passed_last_run" field to hydra_heuristics.yml.

This allows a rake task such as the following to be written:
https://gist.github.com/1120614

It takes all the files that failed during the last hydra run, and runs them on the local machine with all the failed files in a single test suite.

I figured that what people decide to do with the failed file info is probably different for everyone (list the files out, re-run them locally, re-run them with hydra?), so the task was not added as a hydra task.

Cheers,
Clemens
